### PR TITLE
F 65 simplify accassing relationships and  attributes

### DIFF
--- a/src/module/resource/ResourceBuilder.js
+++ b/src/module/resource/ResourceBuilder.js
@@ -38,26 +38,8 @@ export class ResourceBuilder {
   buildRelationshipMethods (obj) {
     const relationships = obj.relationships
 
-    for (const currentRelationshipName in relationships) {
-      if (Object.prototype.hasOwnProperty.call(relationships, currentRelationshipName)) {
-        const relatedObject = relationships[currentRelationshipName]
-
-        const relationshipConfig = {
-          isToMany: relatedObject.data.constructor === Array
-        }
-
-        relatedObject.get = getRelationship(this.store, relatedObject, relationshipConfig)
-        relatedObject.load = loadRelationship(this.store, obj.id, obj.type, relatedObject, relationshipConfig)
-
-        if (relationshipConfig.isToMany) {
-          relatedObject.list = listRelationship(this.store, relatedObject)
-        }
-
-        relationships[currentRelationshipName] = relatedObject
-      }
-    }
-
-    obj.relationships = relationships
+    obj.loadRel = (relationshipName) => loadRelationship(this.store, obj.id, obj.type, relationships[relationshipName], getRelationshipConfig(relationships[relationshipName]))()
+    obj.rel = (relationshipName) => getRelationshipConfig(relationships[relationshipName]).isToMany ? listRelationship(this.store, relationships[relationshipName])() : getRelationship(this.store, relationships[relationshipName], getRelationshipConfig(relationships[relationshipName]))()
   }
 
   /**
@@ -68,5 +50,17 @@ export class ResourceBuilder {
   */
   static strip (functionalResourceObject) {
     return JSON.parse(JSON.stringify(functionalResourceObject))
+  }
+}
+
+/**
+ * Config Getter for the RelationshipMethod
+ *
+ * @param relatedObject
+ * @return {{isToMany: boolean}}
+ */
+function getRelationshipConfig (relatedObject) {
+  return {
+    isToMany: relatedObject.data.constructor === Array
   }
 }

--- a/src/module/resource/ResourceBuilder.js
+++ b/src/module/resource/ResourceBuilder.js
@@ -26,6 +26,8 @@ export class ResourceBuilder {
     obj.hasLoadableRelationship = hasLoadableRelationship(obj)
     obj.hasLoadedRelationship = hasLoadedRelationship(obj)
 
+    obj.get = (attributeName) => Object.prototype.hasOwnProperty.call(obj.attributes, attributeName) ? obj.attributes[attributeName] : null
+
     if (obj.hasRelationship) {
       this.buildRelationshipMethods(obj)
     }


### PR DESCRIPTION
May we want to rewrite the access for attributes and relationships in a way, that the person using the plugin doesn't has to write so much?
at the moment it looks like this:
`myObj.attributes.name` and `myObj.relationships.siblings.get()`

I request to change it to:
`myObj.get('name')` and `myObj.rel('siblings')`

Related issues: #65 

of change:

[x] Code
[] Just documentation

If code was changed, did you...

[x] ...write/update unit tests?
[] ...write/update documentation?
