### PR TITLE
simplify access to relationships and attributes

### DIFF
--- a/src/module/resource/ResourceBuilder.js
+++ b/src/module/resource/ResourceBuilder.js
@@ -38,26 +38,8 @@ export class ResourceBuilder {
   buildRelationshipMethods (obj) {
     const relationships = obj.relationships
 
-    for (const currentRelationshipName in relationships) {
-      if (Object.prototype.hasOwnProperty.call(relationships, currentRelationshipName)) {
-        const relatedObject = relationships[currentRelationshipName]
-
-        const relationshipConfig = {
-          isToMany: relatedObject.data.constructor === Array
-        }
-
-        relatedObject.get = getRelationship(this.store, relatedObject, relationshipConfig)
-        relatedObject.load = loadRelationship(this.store, obj.id, obj.type, relatedObject, relationshipConfig)
-
-        if (relationshipConfig.isToMany) {
-          relatedObject.list = listRelationship(this.store, relatedObject)
-        }
-
-        relationships[currentRelationshipName] = relatedObject
-      }
-    }
-
-    obj.relationships = relationships
+    obj.loadRel = (relationshipName) => loadRelationship(this.store, obj.id, obj.type, relationships[relationshipName], getRelationshipConfig(relationships[relationshipName]))()
+    obj.rel = (relationshipName) => getRelationshipConfig(relationships[relationshipName]).isToMany ? listRelationship(this.store, relationships[relationshipName])() : getRelationship(this.store, relationships[relationshipName], getRelationshipConfig(relationships[relationshipName]))()
   }
 
   /**
@@ -68,5 +50,17 @@ export class ResourceBuilder {
   */
   static strip (functionalResourceObject) {
     return JSON.parse(JSON.stringify(functionalResourceObject))
+  }
+}
+
+/**
+ * Config Getter for the RelationshipMethod
+ *
+ * @param relatedObject
+ * @return {{isToMany: boolean}}
+ */
+function getRelationshipConfig (relatedObject) {
+  return {
+    isToMany: relatedObject.data.constructor === Array
   }
 }

--- a/src/module/resource/ResourceBuilder.js
+++ b/src/module/resource/ResourceBuilder.js
@@ -26,6 +26,8 @@ export class ResourceBuilder {
     obj.hasLoadableRelationship = hasLoadableRelationship(obj)
     obj.hasLoadedRelationship = hasLoadedRelationship(obj)
 
+    obj.get = (attributeName) => Object.prototype.hasOwnProperty.call(obj.attributes, attributeName) ? obj.attributes[attributeName] : null
+
     if (obj.hasRelationship) {
       this.buildRelationshipMethods(obj)
     }

--- a/src/module/resource/ResourceBuilder.js
+++ b/src/module/resource/ResourceBuilder.js
@@ -26,7 +26,7 @@ export class ResourceBuilder {
     obj.hasLoadableRelationship = hasLoadableRelationship(obj)
     obj.hasLoadedRelationship = hasLoadedRelationship(obj)
 
-    obj.get = (attributeName) => Object.prototype.hasOwnProperty.call(obj.attributes, attributeName) ? obj.attributes[attributeName] : null
+    obj.get = (attributeName) => Object.prototype.hasOwnProperty.call(obj.attributes, attributeName) ? obj.attributes[attributeName] : new Error(`attribute "${attributeName}" not found`)
 
     if (obj.hasRelationship) {
       this.buildRelationshipMethods(obj)

--- a/src/module/resource/ResourceBuilder.js
+++ b/src/module/resource/ResourceBuilder.js
@@ -35,11 +35,45 @@ export class ResourceBuilder {
     return obj
   }
 
+  /**
+   * Adds Methods (get, load, list) to the relationships for getting / loading them
+   * Adds Shorthand Methods (rel / loadRel)
+   *
+   * @param {Object} jsonResourceObject
+   */
   buildRelationshipMethods (obj) {
     const relationships = obj.relationships
 
-    obj.loadRel = (relationshipName) => loadRelationship(this.store, obj.id, obj.type, relationships[relationshipName], getRelationshipConfig(relationships[relationshipName]))()
-    obj.rel = (relationshipName) => getRelationshipConfig(relationships[relationshipName]).isToMany ? listRelationship(this.store, relationships[relationshipName])() : getRelationship(this.store, relationships[relationshipName], getRelationshipConfig(relationships[relationshipName]))()
+    for (const currentRelationshipName in relationships) {
+      if (Object.prototype.hasOwnProperty.call(relationships, currentRelationshipName)) {
+        const relatedObject = relationships[currentRelationshipName]
+
+        const relationshipConfig = {
+          isToMany: relatedObject.data.constructor === Array
+        }
+
+        relatedObject.get = getRelationship(this.store, relatedObject, relationshipConfig)
+        relatedObject.load = loadRelationship(this.store, obj.id, obj.type, relatedObject, relationshipConfig)
+
+        if (relationshipConfig.isToMany) {
+          relatedObject.list = listRelationship(this.store, relatedObject)
+        }
+
+        relationships[currentRelationshipName] = relatedObject
+      }
+    }
+
+    // shorthand variant
+    obj.loadRel = (relationshipName) => {
+      return loadRelationship(this.store, obj.id, obj.type, relationships[relationshipName], getRelationshipConfig(relationships[relationshipName]))()
+    }
+    obj.rel = (relationshipName) => {
+      if (getRelationshipConfig(relationships[relationshipName]).isToMany) {
+        return listRelationship(this.store, relationships[relationshipName])()
+      } else {
+        return getRelationship(this.store, relationships[relationshipName], getRelationshipConfig(relationships[relationshipName]))()
+      }
+    }
   }
 
   /**

--- a/test/resource/ResourceBuilder.spec.js
+++ b/test/resource/ResourceBuilder.spec.js
@@ -1,4 +1,5 @@
 import { ResourceBuilder } from '@/module/resource/ResourceBuilder'
+import Vuex from 'vuex'
 
 describe('ResourceBuilder', () => {
   const jsonResourceMock = {
@@ -28,14 +29,27 @@ describe('ResourceBuilder', () => {
           ]
         }
       }
-    }
+    },
+    includeds: [{
+      id: 'cc1',
+      type: 'relObjs',
+      attributes: {
+        name: 'relative lame name',
+        anotherProp: 'test'
+      }
+    }]
   }
 
-  it('shoud add a "get" Method wich returns the vaue from the given attribute', () => {
-    const obj = new ResourceBuilder().build(jsonResourceMock)
+  const obj = new ResourceBuilder(Vuex).build(jsonResourceMock)
+  it('shoud add a "get" Method wich returns the value from the given attribute', () => {
     expect(typeof obj.get).toBe('function')
 
     expect(obj.get('name')).toBe(jsonResourceMock.data.attributes.name)
-    expect(obj.get('fail')).toBe(null)
+    expect(obj.get('fail')).toEqual(new Error(`attribute "fail" not found`))
+  })
+
+  it('shoud return the value from the given attribute', () => {
+    expect(obj.attributes.name).toBe(jsonResourceMock.data.attributes.name)
+    expect(obj.attributes.fail).toBe(undefined)
   })
 })

--- a/test/resource/ResourceBuilder.spec.js
+++ b/test/resource/ResourceBuilder.spec.js
@@ -1,0 +1,41 @@
+import { ResourceBuilder } from '@/module/resource/ResourceBuilder'
+
+describe('ResourceBuilder', () => {
+  const jsonResourceMock = {
+    data: {
+      attributes: {
+        name: 'Some Name'
+      },
+      id: 'aa1',
+      type: 'test',
+      relationships: {
+        relatedObject: {
+          data: {
+            id: 'cc1',
+            type: 'relatedObject'
+          }
+        },
+        relObjs: {
+          data: [
+            {
+              id: 'cc1',
+              type: 'relObjs'
+            },
+            {
+              id: 'cc2',
+              type: 'relObjs'
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  it('shoud add a "get" Method wich returns the vaue from the given attribute', () => {
+    const obj = new ResourceBuilder().build(jsonResourceMock)
+    expect(typeof obj.get).toBe('function')
+
+    expect(obj.get('name')).toBe(jsonResourceMock.data.attributes.name)
+    expect(obj.get('fail')).toBe(null)
+  })
+})

--- a/test/server/getTestServer.js
+++ b/test/server/getTestServer.js
@@ -1,58 +1,60 @@
 // const FakeServer = require('fake-json-api-server/src/nodeServer')
 import { JsonApiServerAdapter } from './JsonApiServerAdapter'
 
-const serverConfig = {
-  resources: {
-    tag: {
-      data: [
-        {
-          type: 'tag',
-          id: '1',
-          attributes: { title: 'Tag 1' }
+const testResources = {
+  tag: {
+    data: [
+      {
+        type: 'tag',
+        id: '1',
+        attributes: { title: 'Tag 1' }
+      },
+      {
+        type: 'tag',
+        id: '2',
+        attributes: { title: 'Tag 2' }
+      }
+    ]
+  },
+  article: {
+    data: [
+      {
+        type: 'article',
+        id: '1',
+        attributes: {
+          title: 'Foo',
+          text: 'Lorem ipsum hodor sit sit sit.'
         },
-        {
-          type: 'tag',
-          id: '2',
-          attributes: { title: 'Tag 2' }
-        }
-      ]
-    },
-    article: {
-      data: [
-        {
-          type: 'article',
-          id: '1',
-          attributes: {
-            title: 'Foo',
-            text: 'Lorem ipsum hodor sit sit sit.'
-          },
-          relationships: {
-            tags: {
-              data: [
-                { type: 'tag', id: '1' },
-                { type: 'tag', id: '2' }
-              ]
-            }
-          }
-        },
-        {
-          type: 'article',
-          id: '1',
-          attributes: {
-            title: 'Bar',
-            text: 'Barium is not something you want to keep lying around on the kitchen table.'
-          },
-          relationships: {
-            tags: {
-              data: [
-                { type: 'tag', id: '1' }
-              ]
-            }
+        relationships: {
+          tags: {
+            data: [
+              { type: 'tag', id: '1' },
+              { type: 'tag', id: '2' }
+            ]
           }
         }
-      ]
-    }
+      },
+      {
+        type: 'article',
+        id: '1',
+        attributes: {
+          title: 'Bar',
+          text: 'Barium is not something you want to keep lying around on the kitchen table.'
+        },
+        relationships: {
+          tags: {
+            data: [
+              { type: 'tag', id: '1' }
+            ]
+          }
+        }
+      }
+    ]
   }
+}
+
+const serverConfig = {
+  resources: testResources
 }
 
 function getTestServer (port) {
@@ -61,4 +63,5 @@ function getTestServer (port) {
 
   return app.listen(port)
 }
-export { getTestServer }
+
+export { getTestServer, testResources }


### PR DESCRIPTION
Related issues: #65 

Type of change:
change the Way t o access attributes and relationships:
before
`myObj,attributes.name`
`myObj.relationships.sibling.get()`

after
`myObj.get('name')`
`myObj.rel('sibling')`

[X] Code
[] Just documentation

If code was changed, did you...

[X] ...write/update unit tests?
[] ...write/update documentation?
