### PR TITLE
Change how the linter works

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "npm": ">= 3.0.0"
   },
   "lint-staged": {
-    "*.js": "eslint"
+    "*.js": ["eslint --fix", "jest --bail --findRelatedTests"]
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://vuex-json-api.efrane.com",
   "main": "index.js",
   "scripts": {
-    "unit": "jest --config jest.config.js",
+    "unit": "jest --detectOpenHandles --config jest.config.js",
     "test": "yarn unit",
     "tdd": "yarn unit --watch",
     "lint": "eslint --ext .js,.vue src test",
@@ -45,6 +45,7 @@
     "husky": "^4.0.7",
     "jest": "^25.1.0",
     "jest-transform-stub": "^2.0.0",
+    "lint-staged": "^10.0.8",
     "vue": "^2.6.10",
     "vue-jest": "^3.0.5",
     "vue-template-compiler": "^2.5.2",
@@ -55,9 +56,12 @@
     "node": ">= 8.0.0",
     "npm": ">= 3.0.0"
   },
+  "lint-staged": {
+    "*.js": "eslint"
+  },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint",
+      "pre-commit": "yarn run lint-staged",
       "pre-push": "yarn test"
     }
   }

--- a/src/module/actions/options/saveOptions.js
+++ b/src/module/actions/options/saveOptions.js
@@ -1,4 +1,4 @@
-import { deepMerge } from '@/helpers/deepMerge'
+import { deepMerge } from '../../../helpers/deepMerge'
 
 export function saveOptions ({ currentItemState, changedItemState, options }) {
   const returnedItemState = JSON.parse(JSON.stringify(changedItemState))


### PR DESCRIPTION
Related issues: -

There's really no need to run all the linter and test stuff on each commit locally as that should be the job of the CI. This PR introduces `lint-staged` with a basic configuration.

**Up for debate**: Should we remove or adjust the githook to run all tests on push?

Type of change:

[x] Code
[] Just documentation

If code was changed, did you...

[] ...write/update unit tests?
[] ...write/update documentation?
