### PR TITLE
remove moduleName from saveAction again

### DIFF
--- a/src/module/actions/saveAction.js
+++ b/src/module/actions/saveAction.js
@@ -53,7 +53,7 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
         changedItemState = applySaveOptions({ currentItemState, changedItemState, options })
       }
 
-      vuexFns.commit(moduleName + '/startLoading', null)
+      vuexFns.commit('startLoading', null)
 
       return api[moduleName].update(
         { id },
@@ -70,7 +70,7 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
         }
         processResponseData(thisArg, vuexFns, api, moduleName, data, 'update')
 
-        vuexFns.commit(moduleName + '/endLoading', null)
+        vuexFns.commit('endLoading', null)
       })
     }
   })


### PR DESCRIPTION
adding the moduleName fixed the test, but broke the lib. now the tests pass, but we get console errors for the saveAction.spec

Related issues: #xxx, #yyy, ...

Type of change:

[x] Code
[] Just documentation

If code was changed, did you...

[] ...write/update unit tests?
[] ...write/update documentation?
