### PR TITLE
200 with no content is a valid response

### DIFF
--- a/src/module/actions/saveAction.js
+++ b/src/module/actions/saveAction.js
@@ -73,7 +73,7 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
         
         if (status === 200) {
           const isEmptyArray = Array.isArray(data) === true && data.length === 0
-          const isEmptyObject = typeof data === 'object' && data !== null
+          const isEmptyObject = typeof data === 'object' && data !== null && Object.keys(data).length === 0
           const isNull = data === null
           if (isEmptyArray || isEmptyObject || isNull) {
             vuexFns.commit('set', getExpectedResponse(currentItemState))

--- a/src/module/actions/saveAction.js
+++ b/src/module/actions/saveAction.js
@@ -67,7 +67,7 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
             })
         }
       ).then(({ data, status }) => {
-        if (status === 204) {
+        if (status === 204 || status === 200) {
           vuexFns.commit('set', getExpectedResponse(currentItemState))
         }
         processResponseData(thisArg, vuexFns, api, moduleName, data, 'update')

--- a/src/module/actions/saveAction.js
+++ b/src/module/actions/saveAction.js
@@ -67,9 +67,19 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
             })
         }
       ).then(({ data, status }) => {
-        if (status === 204 || status === 200) {
+        if (status === 204) {
           vuexFns.commit('set', getExpectedResponse(currentItemState))
         }
+        
+        if (status === 200) {
+          const isEmptyArray = Array.isArray(data) === true && data.length === 0
+          const isEmptyObject = typeof data === 'object' && data !== null
+          const isNull = data === null
+          if (isEmptyArray || isEmptyObject || isNull) {
+            vuexFns.commit('set', getExpectedResponse(currentItemState))
+          }
+        }
+        
         processResponseData(thisArg, vuexFns, api, moduleName, data, 'update')
 
         vuexFns.commit('endLoading', null)


### PR DESCRIPTION
````
 server MUST return a 200 OK status code if an update is successful, the client’s current fields remain up to date, and the server responds only with top-level meta data. In this case the server MUST NOT include a representation of the updated resource(s).
````

Related issues: #xxx, #yyy, ...

Type of change:

[x] Code
[] Just documentation

If code was changed, did you...

[] ...write/update unit tests?
[] ...write/update documentation?
