### PR TITLE
pass resourceFull Object instead of {}

### DIFF
--- a/src/module/helpers/missingModule.js
+++ b/src/module/helpers/missingModule.js
@@ -19,7 +19,7 @@ export function isMissingModule (store, moduleName) {
  * @param {String} moduleName
  */
 export function registerMissingModule (store, api, moduleName) {
-  const builder = new ModuleBuilder(store, api, moduleName, new ResourceProxy(), { standalone: true })
+  const builder = new ModuleBuilder(store, api, moduleName, api[moduleName] ?? new ResourceProxy(), { standalone: true })
 
   store.registerModule(
     moduleName,

--- a/src/module/helpers/missingModule.js
+++ b/src/module/helpers/missingModule.js
@@ -1,4 +1,5 @@
 import { ModuleBuilder } from '../ModuleBuilder'
+import { ResourceProxy } from '../../api/ResourceProxy'
 
 /**
  * Check if a module is registered in the store
@@ -18,7 +19,7 @@ export function isMissingModule (store, moduleName) {
  * @param {String} moduleName
  */
 export function registerMissingModule (store, api, moduleName) {
-  const builder = new ModuleBuilder(store, api, moduleName, {}, { standalone: true })
+  const builder = new ModuleBuilder(store, api, moduleName, new ResourceProxy(), { standalone: true })
 
   store.registerModule(
     moduleName,


### PR DESCRIPTION
otherwise the ModuleBuilder fails.
within there `apiMethods` are expected to have an `isCollection` Method
(and others)

Related issues: #xxx, #yyy, ...

Type of change:

[x] Code
[] Just documentation

If code was changed, did you...

[] ...write/update unit tests?
[] ...write/update documentation?
