### PR TITLE
feat(): pass responses from actions

### DIFF
--- a/src/module/actions/createAction.js
+++ b/src/module/actions/createAction.js
@@ -15,10 +15,12 @@ export function createAction (api, moduleName) {
       vuexFns.commit('startLoading')
 
       // It is currently not supported to pass query params when creating a new resource
-      return api[moduleName].create(null, { data: resourceObject }).then(({ data }) => {
-        processResponseData(thisArg, vuexFns, api, moduleName, data, 'create')
+      return api[moduleName].create(null, { data: resourceObject }).then(response => {
+        processResponseData(thisArg, vuexFns, api, moduleName, response.data, 'create')
 
         vuexFns.commit('endLoading')
+
+        return response
       })
     }
   })

--- a/src/module/actions/getAction.js
+++ b/src/module/actions/getAction.js
@@ -14,10 +14,12 @@ export function getAction (api, moduleName, defaultQuery) {
 
       vuexFns.commit('startLoading')
 
-      return api[moduleName].get(query).then(({ data }) => {
-        processResponseData(thisArg, vuexFns, api, moduleName, data, 'get')
+      return api[moduleName].get(query).then(response => {
+        processResponseData(thisArg, vuexFns, api, moduleName, response.data, 'get')
 
         vuexFns.commit('endLoading')
+
+        return response
       })
     }
   })

--- a/src/module/actions/listAction.js
+++ b/src/module/actions/listAction.js
@@ -17,15 +17,17 @@ export function listAction (api, moduleName, defaultQuery, module) {
 
       vuexFns.commit('startLoading')
 
-      return api[moduleName].list(query).then(({ data, meta }) => {
+      return api[moduleName].list(query).then(response => {
         vuexFns.commit('resetItems')
-        processResponseData(thisArg, vuexFns, api, moduleName, data, 'list', module)
+        processResponseData(thisArg, vuexFns, api, moduleName, response.data, 'list', module)
 
-        if (meta && hasOwn(meta, 'pagination')) {
-          vuexFns.commit('setPagination', meta.pagination)
+        if (response.meta && hasOwn(response.meta, 'pagination')) {
+          vuexFns.commit('setPagination', response.meta.pagination)
         }
 
         vuexFns.commit('endLoading')
+
+        return response
       })
     }
   })

--- a/src/module/actions/listRelatedAction.js
+++ b/src/module/actions/listRelatedAction.js
@@ -18,15 +18,17 @@ export function listRelatedAction (api, moduleName, relatedModuleName) {
       vuexFns.commit('startLoading')
       vuexFns.commit(`${relatedModuleName}/startLoading`, null, { root: true })
 
-      return api[moduleName].related[relatedModuleName].list(query).then(({ data, meta }) => {
-        processResponseData(thisArg, vuexFns, api, moduleName, data, 'list')
+      return api[moduleName].related[relatedModuleName].list(query).then(response => {
+        processResponseData(thisArg, vuexFns, api, moduleName, response.data, 'list')
 
-        if (hasOwn(meta, 'pagination')) {
-          vuexFns.commit(`${relatedModuleName}setPagination`, meta.pagination)
+        if (hasOwn(response.meta, 'pagination')) {
+          vuexFns.commit(`${relatedModuleName}setPagination`, response.meta.pagination)
         }
 
         vuexFns.commit(`${relatedModuleName}/endLoading`, null, { root: true })
         vuexFns.commit('endLoading')
+
+        return response
       })
     }
   })

--- a/src/module/actions/saveAction.js
+++ b/src/module/actions/saveAction.js
@@ -66,7 +66,9 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
               type: currentItemState.type
             })
         }
-      ).then(({ data, status }) => {
+      ).then(response => {
+        const { data, status } = response
+
         if (status === 204) {
           vuexFns.commit('set', getExpectedResponse(currentItemState))
         }
@@ -83,6 +85,8 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
         processResponseData(thisArg, vuexFns, api, moduleName, data, 'update')
 
         vuexFns.commit('endLoading', null)
+
+        return response
       })
     }
   })


### PR DESCRIPTION
Related issues: #xxx, #yyy, ...

to enable some custom handling of the response body, it should be passted through the actions. 


Type of change:

[x] Code
[] Just documentation

If code was changed, did you...

[] ...write/update unit tests?
[] ...write/update documentation?
