### PR TITLE
pass resourceFull Object instead of 'undefined'

### DIFF
--- a/src/api/ResourcefulApi.js
+++ b/src/api/ResourcefulApi.js
@@ -79,7 +79,13 @@ export class ResourcefulApi extends Api {
   setupApiModules (apiModulesToRegister = []) {
     Performance.mark('api_setup_modules_start')
 
-    apiModulesToRegister.forEach(moduleName => this.registerModule(moduleName, this[moduleName]))
+    apiModulesToRegister.forEach(moduleName => {
+      let resourceProxy = this[moduleName]
+      if (!resourceProxy) {
+        resourceProxy = new ResourceProxy()
+      }
+      this.registerModule(moduleName, resourceProxy)
+    })
 
     Performance.mark('api_setup_modules_end')
     Performance.measure(

--- a/src/module/preset/createPresetModule.js
+++ b/src/module/preset/createPresetModule.js
@@ -17,11 +17,14 @@ export function createPresetModule (store, api) {
         registerBaseModule(store, api, baseModule)
       }
 
-      const methods = api[baseModule]
+      let resourceProxy = api[baseModule]
+      if (!resourceProxy) {
+        resourceProxy = new ResourceProxy()
+      }
 
       Performance.mark('module_register_preset_start')
 
-      const builder = new ModuleBuilder(store, api, baseModule, methods, {
+      const builder = new ModuleBuilder(store, api, baseModule, resourceProxy, {
         presetOptions: {
           defaultQuery: checkConfigProperty(config, 'defaultQuery', false) ? config.defaultQuery : {}
         }


### PR DESCRIPTION
otherwise the ModuleBuilder fails because apiMethods always have to be a ressourceFullApi