### PR TITLE
feat(refs #195): Introduce deref() function

### DIFF
--- a/src/api/ResourcefulApi.js
+++ b/src/api/ResourcefulApi.js
@@ -3,7 +3,7 @@ import normalize from 'json-api-normalizer'
 import { Api } from './Api'
 import { ModuleBuilder } from '../module/ModuleBuilder'
 import { ResourceProxy } from './ResourceProxy'
-import { hasOwn } from '../shared/utils'
+import { deref, hasOwn } from '../shared/utils'
 import { Performance } from '../shared/Performance'
 
 /**
@@ -49,7 +49,7 @@ export class ResourcefulApi extends Api {
    * @return {*}
    */
   preprocessData (data) {
-    data = JSON.parse(JSON.stringify(data))
+    data = deref(data)
     data.data.type = data.data.type.charAt(0).toUpperCase() + data.data.type.slice(1)
 
     if (data.data.relationships) {

--- a/src/helpers/validateCallbackFn.js
+++ b/src/helpers/validateCallbackFn.js
@@ -1,7 +1,9 @@
+/**
+ * Make sure a passed parameter is actually a function
+ *
+ * @param fn
+ * @returns {boolean}
+ */
 export function validateCallbackFn (fn) {
-  if (fn.constructor !== Function) {
-    return false
-  }
-
-  return true
+  return fn.constructor === Function
 }

--- a/src/module/State.js
+++ b/src/module/State.js
@@ -1,5 +1,6 @@
 import { item } from './state/item'
 import { collection } from './state/collection'
+import { deref } from '../shared/utils'
 
 /**
  * Return a new Object representing the initial state of a module
@@ -13,9 +14,9 @@ import { collection } from './state/collection'
 function initialState (isCollection) {
   return (() => {
     if (isCollection) {
-      return JSON.parse(JSON.stringify(collection))
+      return deref(collection)
     } else {
-      return JSON.parse(JSON.stringify(item))
+      return deref(item)
     }
   })()
 }

--- a/src/module/actions/options/saveOptions.js
+++ b/src/module/actions/options/saveOptions.js
@@ -1,7 +1,7 @@
-import { deepMerge, hasOwn } from '../../../shared/utils'
+import { deepMerge, deref, hasOwn } from '../../../shared/utils'
 
 export function saveOptions ({ currentItemState, changedItemState, options }) {
-  const returnedItemState = JSON.parse(JSON.stringify(changedItemState))
+  const returnedItemState = deref(changedItemState)
   if (typeof options !== 'undefined' && hasOwn(returnedItemState, 'attributes')) {
     Object.keys(options).forEach(option => {
       switch (option) {

--- a/src/module/actions/saveAction.js
+++ b/src/module/actions/saveAction.js
@@ -2,7 +2,7 @@ import { diff } from 'deep-object-diff'
 import { processResponseData } from '../helpers/processResponseData'
 import { getExpectedResponse } from '../helpers/getExpectedResponse'
 import { saveOptions as applySaveOptions } from './options/saveOptions'
-import { hasOwn } from '../../shared/utils'
+import { deref, hasOwn } from '../../shared/utils'
 
 /**
  * Update an existing resource
@@ -28,18 +28,18 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
       if (hasOwn(defaultQuery, 'group')) {
         if (isCollection) {
           currentItemState = thisArg.state[moduleName][defaultQuery.group].items[id]
-          initialItemState = JSON.parse(JSON.stringify(thisArg.state[moduleName][defaultQuery.group].initial[id]))
+          initialItemState = deref(thisArg.state[moduleName][defaultQuery.group].initial[id])
         } else {
           currentItemState = thisArg.state[moduleName][defaultQuery.group].item
-          initialItemState = JSON.parse(JSON.stringify(thisArg.state[moduleName][defaultQuery.group].initial))
+          initialItemState = deref(thisArg.state[moduleName][defaultQuery.group].initial)
         }
       } else {
         if (isCollection) {
           currentItemState = thisArg.state[moduleName].items[id]
-          initialItemState = JSON.parse(JSON.stringify(thisArg.state[moduleName].initial[id]))
+          initialItemState = deref(thisArg.state[moduleName].initial[id])
         } else {
           currentItemState = thisArg.state[moduleName].item
-          initialItemState = JSON.parse(JSON.stringify(thisArg.state[moduleName].initial))
+          initialItemState = deref(thisArg.state[moduleName].initial)
         }
       }
 

--- a/src/module/resource/ResourceBuilder.js
+++ b/src/module/resource/ResourceBuilder.js
@@ -4,7 +4,7 @@ import { hasLoadedRelationship } from './hasLoadedRelationship'
 import { listRelationship } from './listRelationship'
 import { loadRelationship } from './loadRelationship'
 import { getRelationship } from './getRelationship'
-import { hasOwn } from '../../shared/utils'
+import { deref, hasOwn } from '../../shared/utils'
 
 /**
  * @class ResourceBuilder
@@ -24,7 +24,7 @@ export class ResourceBuilder {
   * @param {Object} jsonResourceObject
   */
   build (jsonResourceObject) {
-    const obj = JSON.parse(JSON.stringify(jsonResourceObject.data)) // why tho?
+    const obj = deref(jsonResourceObject.data) // why tho?
 
     obj.hasRelationship = hasRelationship(obj)
     obj.hasLoadableRelationship = hasLoadableRelationship(obj)
@@ -87,7 +87,7 @@ export class ResourceBuilder {
   * @param {Object} functionalResourceObject
   */
   static strip (functionalResourceObject) {
-    return JSON.parse(JSON.stringify(functionalResourceObject))
+    return deref(functionalResourceObject)
   }
 }
 

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -42,3 +42,13 @@ export function deepMerge (target, source) {
 
   return target
 }
+
+/**
+ * De-reference objects
+ *
+ * @param {object} obj
+ * @return {object} a dereferenced copy of the passed object
+ */
+export function deref (obj) {
+  return JSON.parse(JSON.stringify(obj))
+}

--- a/test/shared/utils.spec.js
+++ b/test/shared/utils.spec.js
@@ -1,0 +1,9 @@
+import { deref } from '@/shared/utils'
+
+test('dereferences objects', () => {
+  const testObj = { foo: 'bar' }
+  const dereferenced = deref(testObj)
+
+  expect(dereferenced).not.toBe(testObj)
+  expect(dereferenced).toEqual(testObj)
+})


### PR DESCRIPTION
<!-- 
    Please add a short description of what the PR changes.
    If possible, also add/update the corresponding unit tests.
-->

This moves the `JSON.parse(JSON.stringify(`-logic into `utils.deref`, improving code readability and making it much easier to replace this sledge hammer serialization approach to derefencing with something else one day.