### PR TITLE
fix: re-add data that got lost in refactoring

### DIFF
--- a/src/module/resource/ResourceBuilder.js
+++ b/src/module/resource/ResourceBuilder.js
@@ -25,7 +25,7 @@ export class ResourceBuilder {
   */
   build (jsonResourceObject) {
     if (hasOwn(jsonResourceObject, 'id')) {
-      const item = deref(jsonResourceObject) // why tho?
+      const item = deref(jsonResourceObject.data) // why tho?
 
       return this.functionalizeItem(item)
     }


### PR DESCRIPTION
We need to access `data` on the `jsonResourceObject`, not the `jsonResourceeObject` directly. This got lost in a refactoring and led to items being wrapped in a data object.