### PR TITLE
fix: use correct mutation

### DIFF
--- a/src/module/actions/saveAction.js
+++ b/src/module/actions/saveAction.js
@@ -70,7 +70,7 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
         const { data, status } = response
 
         if (status === 204) {
-          vuexFns.commit('set', getExpectedResponse(currentItemState))
+          vuexFns.commit('setItem', getExpectedResponse(currentItemState))
         }
 
         if (status === 200) {
@@ -78,7 +78,7 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
           const isEmptyObject = typeof data === 'object' && data !== null && Object.keys(data).length === 0
           const isNull = data === null
           if (isEmptyArray || isEmptyObject || isNull) {
-            vuexFns.commit('set', getExpectedResponse(currentItemState))
+            vuexFns.commit('setItem', getExpectedResponse(currentItemState))
           }
         }
 


### PR DESCRIPTION
- in a refactoring, the `setMuation` was adjusted to be used only for the inital setting of a single item module
- in the `saveAction`, we should instead use the `setItemMutation`, which sets either a single item in a collection or the item in a single item module
