### PR TITLE
fix: use correct mutation on restoreFromInitial

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - use correct mutation on save (@hwiem)
 - do not add data object to resource on save (@hwiem)
+- use correct mutation on restoreFromInitial (@hwiem)
 
 # v0.0.34
 

--- a/src/module/actions/restoreFromInitialAction.js
+++ b/src/module/actions/restoreFromInitialAction.js
@@ -9,7 +9,7 @@ export function restoreFromInitialAction (moduleName, presetModuleName, isCollec
         item = isCollection ? thisArg.state[moduleName][presetModuleName].initial[id] : item = thisArg.state[moduleName][presetModuleName].initial
       }
 
-      vuexFns.commit('set', { id: id, data: item })
+      vuexFns.commit('setItem', { id: id, ...item })
     }
   })
 }


### PR DESCRIPTION
- in a refactoring, the `setMutation` was adjusted to be used only for the initial setting of a single item module
- in the `restoreFromInitialAction`, we should instead use the `setItemMutation`, which sets either a single item in a collection or the item in a single item module