### PR TITLE
fix: update initial after save

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # next version
 
 - fix listRelationships for "to one"-relationships 
+- fix storing data on save in collections
 
 # v0.0.35
 

--- a/src/module/actions/saveAction.js
+++ b/src/module/actions/saveAction.js
@@ -70,7 +70,7 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
         const { data, status } = response
 
         if (status === 204) {
-          vuexFns.commit('setItem', getExpectedResponse(currentItemState))
+          vuexFns.commit('set', getExpectedResponse(currentItemState))
         }
 
         if (status === 200) {
@@ -78,7 +78,7 @@ export function saveAction (api, isCollection, moduleName, defaultQuery = {}) {
           const isEmptyObject = typeof data === 'object' && data !== null && Object.keys(data).length === 0
           const isNull = data === null
           if (isEmptyArray || isEmptyObject || isNull) {
-            vuexFns.commit('setItem', getExpectedResponse(currentItemState))
+            vuexFns.commit('set', getExpectedResponse(currentItemState))
           }
         }
 

--- a/src/module/mutations/setAllMutation.js
+++ b/src/module/mutations/setAllMutation.js
@@ -19,8 +19,8 @@ export function setAllMutation (resourceBuilder) {
         Vue.set(state.items, settablePayload.id, settablePayload)
         Vue.set(state.initial, settablePayload.id, settablePayload)
       } else {
-        state.items = {...state.items, ...settablePayload}
-        state.initial = {...state.initial, ...settablePayload}
+        state.items = { ...state.items, ...settablePayload }
+        state.initial = { ...state.initial, ...settablePayload }
       }
     }
   })

--- a/src/module/mutations/setAllMutation.js
+++ b/src/module/mutations/setAllMutation.js
@@ -1,3 +1,6 @@
+import { hasOwn } from '../../shared/utils'
+import Vue from 'vue'
+
 /**
  * Proxy for setting Resource Objects on a collection module
  *
@@ -12,8 +15,13 @@ export function setAllMutation (resourceBuilder) {
     apply (target, thisArg, [state, payload]) {
       const settablePayload = resourceBuilder.build(payload)
 
-      state.items = { ...state.items, ...settablePayload }
-      state.initial = { ...state.initial, ...settablePayload }
+      if (hasOwn(settablePayload, 'id')) {
+        Vue.set(state.items, settablePayload.id, settablePayload)
+        Vue.set(state.initial, settablePayload.id, settablePayload)
+      } else {
+        state.items = {...state.items, ...settablePayload}
+        state.initial = {...state.initial, ...settablePayload}
+      }
     }
   })
 }


### PR DESCRIPTION
Until now, the response from a save action gets stored via `setItem`which only updates the item(s), but not the initial values.
But since saving means persisting we should update the initial values too. For that i use here the `set` mutation instead of `setItem`

Also I fixed the setAllMutation (wich is `set` for collections ) that it now can handle updating single items within the collection.