### PR TITLE
null relationships should not be removed during preprocessing

### DIFF
--- a/src/api/ResourcefulApi.js
+++ b/src/api/ResourcefulApi.js
@@ -87,6 +87,10 @@ export class ResourcefulApi extends Api {
               type: startChar.charAt(0).toUpperCase() + relationship.data.type.slice(1)
             }
           }
+        } else if (relationship.data === null) {
+          relationships[name] = {
+            data: null
+          }
         }
       }
       data.data.relationships = relationships

--- a/test/api/ResourcefulApi.spec.js
+++ b/test/api/ResourcefulApi.spec.js
@@ -39,3 +39,20 @@ test('reads the initial module list', () => {
 
   expect(registerModuleMock.mock.calls.length).toBe(3)
 })
+
+test('keeps null relationships after preprocessing', () => {
+  const testResource = {
+    data: {
+      id: 1,
+      type: 'User',
+      relationships: {
+        hobbies: {
+          data: null
+        }
+      }
+    }
+  }
+
+  const preprocessedData = api.preprocessData(testResource)
+  expect(preprocessedData.data.relationships.hobbies.data).toBe(null)
+})


### PR DESCRIPTION
Prior to this commit, relationships set to null weren't send due to an error during preprocessing. This fixes that issue. Thorough testing will have to follow in applications using this lib because it was easy to rely on this bug by accident.
