### PR TITLE
chore: expose Route and StaticRoute

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
 import { prepareModuleHashMap } from './src/init/prepareModuleHashMap'
 import { initJsonApiPlugin } from './src/init/initJsonApiPlugin'
+import { Route } from './src/route/Route'
+import { StaticRoute } from './src/route/StaticRoute'
 import { StaticRouter } from './src/route/StaticRouter'
 import { JsonApiRouter } from './src/route/JsonApiRouter'
 import { FosJsRoutingRouter } from './src/route/FosJsRoutingRouter'
 
 export {
   initJsonApiPlugin,
+  Route,
+  StaticRoute,
   StaticRouter,
   JsonApiRouter,
   FosJsRoutingRouter,


### PR DESCRIPTION
expose Route and StaticRoute to allow adding routes on the fly to the store by using the same Class instance even if the call comes from an external source